### PR TITLE
Various improvements

### DIFF
--- a/COM3D2.ModelExportMMD/MaidExtensions.cs
+++ b/COM3D2.ModelExportMMD/MaidExtensions.cs
@@ -130,22 +130,48 @@ namespace COM3D2.ModelExportMMD.Extensions
         // armature to put her into a T-pose.
         public static void ApplyTPose(this Maid maid)
         {
-            maid.body0.m_Bones.GetComponent<Animation>().Stop();
-            maid.body0.Face.AnimationStop();
-            maid.EyeToReset();
-            maid.LockHeadAndEye(true);
-
-            Transform rootTransform = maid.body0.m_Bones.transform;
-
-            foreach (var boneName in TPoseBonesToReset)
+            Animation anim = maid.body0.m_Bones.GetComponent<Animation>();
+            if (anim.enabled)
             {
-                Transform transform = CMT.SearchObjName(rootTransform, boneName);
-                transform.localRotation = Quaternion.identity;
+                maid.body0.m_Bones.GetComponent<Animation>().enabled = false;
+                maid.body0.Face.AnimationStop();
+                maid.EyeToReset();
+                maid.LockHeadAndEye(true);
+                maid.boMabataki = false;
+                maid.body0.Face.morph.EyeMabataki = 0f;
+                maid.body0.Face.morph.FixBlendValues_Face();
+
+                Transform rootTransform = maid.body0.m_Bones.transform;
+
+                foreach (var boneName in TPoseBonesToReset)
+                {
+                    Transform transform = CMT.SearchObjName(rootTransform, boneName);
+                    transform.localRotation = Quaternion.identity;
+                }
+
+                foreach (var entry in TPoseBoneTransformRotations)
+                {
+                    CMT.SearchObjName(rootTransform, entry.Key).localRotation *= entry.Value;
+                }
+
+                foreach (var dbone in maid.body0.m_Bones.GetComponentsInChildren<DynamicBone>())
+                {
+                    if (!dbone.enabled)
+                    {
+                        Debug.Log($"Dynamic Bone {dbone.name} is already disabled");
+                    }
+                    dbone.enabled = false;
+                }
             }
-
-            foreach (var entry in TPoseBoneTransformRotations)
+            else
             {
-                CMT.SearchObjName(rootTransform, entry.Key).localRotation *= entry.Value;
+                maid.body0.m_Bones.GetComponent<Animation>().enabled = true;
+                maid.LockHeadAndEye(false);
+                maid.boMabataki = true;
+                foreach (var dbone in maid.body0.m_Bones.GetComponentsInChildren<DynamicBone>())
+                {
+                    dbone.enabled = true;
+                }
             }
         }
 

--- a/COM3D2.ModelExportMMD/PmxExporter.cs
+++ b/COM3D2.ModelExportMMD/PmxExporter.cs
@@ -75,34 +75,28 @@ namespace COM3D2.ModelExportMMD
 
         #region Methods
 
-        private PmxVertex.BoneWeight[] ConvertBoneWeight(BoneWeight unityWeight, Transform[] bones, SkinQuality quality)
+        private void ConvertBoneWeight(PmxVertex.BoneWeight[] weights, BoneWeight unityWeight, Transform[] bones)
         {
-            int boneCount = (int)quality;
-            if (boneCount < 1)
-            {
-                boneCount = 1;
-            }
-
-            var weights = new PmxVertex.BoneWeight[boneCount];
-            weights[0].Bone = bonesMap[bones[unityWeight.boneIndex0].name];
             weights[0].Value = unityWeight.weight0;
-            if (boneCount > 1)
+            if (unityWeight.weight0 != 0f)
+            {
+                weights[0].Bone = bonesMap[bones[unityWeight.boneIndex0].name];
+            }
+            weights[1].Value = unityWeight.weight1;
+            if (unityWeight.weight1 != 0f)
             {
                 weights[1].Bone = bonesMap[bones[unityWeight.boneIndex1].name];
-                weights[1].Value = unityWeight.weight1;
             }
-            if (boneCount > 2)
+            weights[2].Value = unityWeight.weight2;
+            if (unityWeight.weight2 != 0f)
             {
                 weights[2].Bone = bonesMap[bones[unityWeight.boneIndex2].name];
-                weights[2].Value = unityWeight.weight2;
             }
-            if (boneCount > 3)
+            weights[3].Value = unityWeight.weight3;
+            if (unityWeight.weight3 != 0f)
             {
                 weights[3].Bone = bonesMap[bones[unityWeight.boneIndex3].name];
-                weights[3].Value = unityWeight.weight3;
             }
-
-            return weights;
         }
 
         private void AddFaceList(int[] faceList, int count)
@@ -146,7 +140,7 @@ namespace COM3D2.ModelExportMMD
             {
                 PmxVertex pmxVertex = new PmxVertex();
                 pmxVertex.UV = new PmxLib.Vector2(uv[i].x, -uv[i].y);
-                pmxVertex.Weight = ConvertBoneWeight(boneWeights[i], meshRender.bones, meshRender.quality);
+                ConvertBoneWeight(pmxVertex.Weight, boneWeights[i], meshRender.bones);
                 Transform t = gameObject.transform;
                 UnityEngine.Vector3 n = normals[i];
                 n = t.TransformDirection(n);
@@ -155,6 +149,7 @@ namespace COM3D2.ModelExportMMD
                 v = t.TransformPoint(v);
                 v *= scaleFactor;
                 pmxVertex.Position = ToPmxVec3(v);
+                pmxVertex.UpdateDeformType();
                 pmxFile.VertexList.Add(pmxVertex);
             }
         }

--- a/COM3D2.ModelExportMMD/PmxExporter.cs
+++ b/COM3D2.ModelExportMMD/PmxExporter.cs
@@ -360,8 +360,8 @@ namespace COM3D2.ModelExportMMD
             info.shadowTex = textureBuilder.Export(ExportFolder, material, "_ShadowTex");
             SetMaterialInfoProperty(out info.shadowColor, material, "_ShadowColor");
             info.shadowRateToon= textureBuilder.Export(ExportFolder, material, "_ShadowRateToon");
-            pmxMaterial.Toon = textureBuilder.Export(ExportFolder, material, "_ToonRamp");
-            info.toonRamp = pmxMaterial.Toon;
+            info.toonRamp = textureBuilder.Export(ExportFolder, material, "_ToonRamp");
+            pmxMaterial.Toon = info.toonRamp ?? "";
             SetMaterialInfoProperty(out info.rimColor, material, "_RimColor");
             SetMaterialInfoProperty(out info.rimPower, material, "_RimPower");
             SetMaterialInfoProperty(out info.rimShift, material, "_RimShift");

--- a/COM3D2.ModelExportMMD/PmxExporter.cs
+++ b/COM3D2.ModelExportMMD/PmxExporter.cs
@@ -213,27 +213,26 @@ namespace COM3D2.ModelExportMMD
             for (int i = 0; i < boneList.Count; i++)
             {
                 Transform bone = boneList[i];
-                if (bone.parent == null || string.IsNullOrEmpty(bone.parent.name) || bone.parent.name.StartsWith("_SM_"))
+                for (Transform parent = bone.parent; parent != null; parent = parent.parent)
+                {
+                    if (bonesMap.ContainsKey(parent.name))
+                    {
+                        int k = bonesMap[parent.name];
+                        if (boneParent[i] == -1)
+                        {
+                            Debug.Log($"Bone {bone.name} parented to {parent.name}({k})");
+                            boneParent[i] = k;
+                        }
+                        else if (boneParent[i] != k)
+                        {
+                            Debug.Log($"Warning: bone {bone.name} was parented to {boneList[boneParent[i]].name} but was also found parented to {parent.name}");
+                        }
+                        break;
+                    }
+                }
+                if (boneParent[i] == -1)
                 {
                     Debug.Log($"Bone {bone.name} has no parent");
-                    continue;
-                }
-                if (bonesMap.ContainsKey(bone.parent.name))
-                {
-                    int k = bonesMap[bone.parent.name];
-                    if (boneParent[i] == -1)
-                    {
-                        Debug.Log($"Bone {bone.name} parented to {bone.parent.name}({k})");
-                        boneParent[i] = k;
-                    }
-                    else if (boneParent[i] != k)
-                    {
-                        Debug.Log($"Warning: bone {bone.name} was parented to {boneList[boneParent[i]].name} but was also found parented to {bone.parent.name}");
-                    }
-                }
-                else
-                {
-                    Debug.LogWarning($"Bone {bone.name} parented to {bone.parent.name} but bone parent index not found");
                 }
             }
 

--- a/COM3D2.ModelExportMMD/PmxExporter.cs
+++ b/COM3D2.ModelExportMMD/PmxExporter.cs
@@ -242,6 +242,7 @@ namespace COM3D2.ModelExportMMD
 
         private void CreateBoneList()
         {
+            List<PmxBone> pmxBoneList = pmxFile.BoneList;
             for (int i = 0; i < boneList.Count; i++)
             {
                 Transform bone = boneList[i];
@@ -254,7 +255,34 @@ namespace COM3D2.ModelExportMMD
                 }
                 UnityEngine.Vector3 vector = bone.position * scaleFactor;
                 pmxBone.Position = ToPmxVec3(vector);
-                pmxFile.BoneList.Add(pmxBone);
+                pmxBone.To_Offset = ToPmxVec3(bone.rotation * UnityEngine.Vector3.left * scaleFactor / 16f);
+                if (bone.name.EndsWith("_SCL_") || bone.name.Contains("twist"))
+                {
+                    pmxBone.SetFlag(PmxBone.BoneFlags.Visible, false);
+                }
+                pmxBoneList.Add(pmxBone);
+            }
+
+            for (int i = 0; i < pmxBoneList.Count; i++)
+            {
+                PmxBone pmxBone = pmxBoneList[i];
+                int children = 0;
+                int lastChildIndex = -1;
+                for (int j = 0; j < pmxBoneList.Count; j++)
+                {
+                    PmxBone pmxOtherBone = pmxBoneList[j];
+                    if (pmxOtherBone.Parent == i && pmxOtherBone.GetFlag(PmxBone.BoneFlags.Visible))
+                    {
+                        children++;
+                        lastChildIndex = j;
+                    }
+                }
+                if (children == 1)
+                {
+                    Debug.Log($"Pointing Bone {pmxBone.NameE} to {pmxBoneList[lastChildIndex].NameE}");
+                    pmxBone.SetFlag(PmxBone.BoneFlags.ToBone, true);
+                    pmxBone.To_Bone = lastChildIndex;
+                }
             }
         }
 

--- a/COM3D2.ModelExportMMD/PmxExporter.cs
+++ b/COM3D2.ModelExportMMD/PmxExporter.cs
@@ -200,40 +200,40 @@ namespace COM3D2.ModelExportMMD
                             boneParent.Add(-1);
                             bindposeList.Add(skinnedMesh.sharedMesh.bindposes[i]);
                         }
+                        else
+                        {
+                            break;
+                        }
                     }
                 }
+            }
 
-                Debug.Log($"Mapping bone parents of {skinnedMesh.name}");
+            Debug.Log($"Mapping bone parents");
 
-                for (int i = 0; i < skinnedMesh.bones.Length; i++)
+            for (int i = 0; i < boneList.Count; i++)
+            {
+                Transform bone = boneList[i];
+                if (bone.parent == null || string.IsNullOrEmpty(bone.parent.name) || bone.parent.name.StartsWith("_SM_"))
                 {
-                    Transform bone = skinnedMesh.bones[i];
-                    if (bone == null || string.IsNullOrEmpty(bone.name))
-                        continue;
-                    if (!bonesMap.TryGetValue(bone.name, out int j))
-                        continue;
-                    if (bone.parent == null || string.IsNullOrEmpty(bone.parent.name) || bone.parent.name.StartsWith("_SM_"))
+                    Debug.Log($"Bone {bone.name} has no parent");
+                    continue;
+                }
+                if (bonesMap.ContainsKey(bone.parent.name))
+                {
+                    int k = bonesMap[bone.parent.name];
+                    if (boneParent[i] == -1)
                     {
-                        Debug.Log($"Bone {bone.name} has no parent");
-                        continue;
+                        Debug.Log($"Bone {bone.name} parented to {bone.parent.name}({k})");
+                        boneParent[i] = k;
                     }
-                    if (bonesMap.ContainsKey(bone.parent.name))
+                    else if (boneParent[i] != k)
                     {
-                        int k = bonesMap[bone.parent.name];
-                        if (boneParent[j] == -1)
-                        {
-                            Debug.Log($"Bone {bone.name} parented to {bone.parent.name}({k})");
-                            boneParent[j] = k;
-                        }
-                        else if (boneParent[j] != k)
-                        {
-                            Debug.Log($"Warning: bone {bone.name} was parented to {boneList[boneParent[j]].name} but was also found parented to {bone.parent.name}");
-                        }
+                        Debug.Log($"Warning: bone {bone.name} was parented to {boneList[boneParent[i]].name} but was also found parented to {bone.parent.name}");
                     }
-                    else
-                    {
-                        Debug.LogWarning($"Bone {bone.name} parented to {bone.parent.name} but bone parent index not found");
-                    }
+                }
+                else
+                {
+                    Debug.LogWarning($"Bone {bone.name} parented to {bone.parent.name} but bone parent index not found");
                 }
             }
 


### PR DESCRIPTION
Here's a set of improvements I've made to this plugin.

Broken PMX export:
PmxMaterial.Toon should be an empty string instead of null

T-Pose Improvements:
Disable blinking
Disable dynamic bones to remove crunched hair
T-Pose can now be undone

Bone Parenting Fix:
Stop adding bones when we hit a bad one, prevents garbage above Bip01
Process all of the bones, not just the ones in skinned meshes list
Forcefully parent bones to the nearest parent, fixes situations where a transform had a _SM_ parent, but _that_ transform's parent was in the bone list.
Much better resulting bone hierarchy

Better PMX Bones:
Bones are rotated properly
(Most) Bones are connected to their children bones

Bone Weight Export Fix:
The model exporter never updated the vertex deform type, leading it to always use 1 bone for deformation
Ignore skin quality entirely, Unity's BoneWeight always has 4 bones, with unused bones of a weight of zero.
There was also an issue where if boneCount was 0 (Auto skin quality) it would assume boneCount of 1, instead of detecting how many bone weights were actually available.
Ensure bone weight of zero stays with bone index of -1

Proper texture alpha fix:
Just check if the material's shader a texture come from has a render queue of 2450 (alpha test) or higher (3000+ is transparent)

Added Vertex Morph Export

Due to some moving of code resulting in indentation changes, you might have a better look over the file changes by adding "?w=1" to the url
https://github.com/pleaserespond/COM3D2.ModelExportMMD/pull/1/files?w=1